### PR TITLE
Update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'clockwork'
+gem "clockwork", "0.5.1"
+gem "tzinfo", "~> 0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    clockwork (0.5.0)
+    clockwork (0.5.1)
       tzinfo (~> 0.3.35)
-    tzinfo (0.3.37)
+    tzinfo (0.3.38)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  clockwork
+  clockwork (= 0.5.1)
+  tzinfo (~> 0.3)


### PR DESCRIPTION
Uses clockwork 0.5.1 as further versions require quite some
  baggage (activesupport) and thus need more testing

Tzinfo now has all tzdata change up to and including 2013g

Signed-off-by: Aleksandrs Ļedovskis aleksandrs@ledovskis.lv
